### PR TITLE
Link both python commands to the same python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,6 @@ RUN apt-get update &&\
                        pkg-config \
                        libblas-dev \
                        liblapack-dev \
-                       python3-pip \
                        python3-tk \
                        python3-wheel \
                        graphviz \
@@ -29,8 +28,8 @@ RUN apt-get update &&\
     add-apt-repository -y ppa:deadsnakes/ppa &&\
     apt install -y python3.7 \
                    python3.7-dev &&\
-    # this relinks pip to python3.7 
-    python3.7 -m pip install --upgrade pip &&\
+    curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py &&\
+    python3.7 get-pip.py &&\
     ln -s /usr/bin/python3.7 /usr/local/bin/python &&\
     ln -s /usr/bin/python3.7 /usr/local/bin/python3 &&\
     apt-get clean &&\

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ RUN apt-get update &&\
     # this relinks pip to python3.7 
     python3.7 -m pip install --upgrade pip &&\
     ln -s /usr/bin/python3.7 /usr/local/bin/python &&\
+    ln -s /usr/bin/python3.7 /usr/local/bin/python3 &&\
     apt-get clean &&\
     # best practice to keep the Docker image lean
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ RUN apt-get update &&\
                    python3.7-dev &&\
     curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py &&\
     python3.7 get-pip.py &&\
+    rm get-pip.py &&\
     ln -s /usr/bin/python3.7 /usr/local/bin/python &&\
     ln -s /usr/bin/python3.7 /usr/local/bin/python3 &&\
     apt-get clean &&\


### PR DESCRIPTION
Currently, the command `python` is linked to `python3.7` and the command `python3` is linked to `python3.6`. This PR links the command `python3` to `python3.7` to avoid confusion.