### PR TITLE
Version lock Pillow and upgrade pytorch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,10 +54,11 @@ RUN pip3 --no-cache-dir install \
          graphviz \
          gpustat \
          h5py \
-         gitpython
+         gitpython \
+         Pillow==6.1.0
 RUN pip3 --no-cache-dir install \
-         torch==1.2.0 \
-         torchvision==0.4.0 \
+         torch==1.3.1 \
+         torchvision==0.4.2 \
          jupyterlab
 RUN pip3 --no-cache-dir install datajoint==0.12.3
 


### PR DESCRIPTION
* `torchvision` is not compatible yet with the latest Pillow (>=7.0.0) and thus needs to be locked at 6.1.0.
* Also updated Pytorch -> 1.3.1
* I suggest that we employ new tagging scheme specifying version of Pytorch, cuda, and DJ, as in: `v1.3.1-cuda10.1-dj0.12.3`
